### PR TITLE
ci: migrate docker build to kaniko (ARC kubernetes mode)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,11 +20,14 @@ jobs:
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
-
-      - name: Push to my internal registry
-        run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Build and push Docker image
+        uses: docker://gcr.io/kaniko-project/executor:v1.23.2-debug
+        with:
+          args: >-
+            --context=/github/workspace
+            --dockerfile=/github/workspace/Dockerfile
+            --destination=macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+            --skip-tls-verify
 
       - name: Run Syft SBoM scan
         uses: anchore/sbom-action@v0.17.8


### PR DESCRIPTION
## Summary

- Replaces `docker build` / `docker push` steps with the kaniko executor container action
- Required because ARC self-hosted runners now use `containerMode: kubernetes` (no Docker daemon available) — see pgmac-net/pgk8s#415

## How it works

Kaniko runs as a `docker://` container action and builds the image directly from the workspace, pushing to `macro.int.pgmac.net:5000` without needing a Docker daemon.

## Test plan

- [ ] CI passes on this PR (build-only, no push)
- [ ] Merge and verify image is pushed to `macro.int.pgmac.net:5000`

Refs: PGM-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)