### PR TITLE
feat: migrate Docker build to remote BuildKit (PGM-155)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,11 +20,18 @@ jobs:
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Set up Docker Buildx (remote BuildKit)
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkitd.arc-runners.svc.cluster.local:1234
 
-      - name: Push to my internal registry
-        run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
 
       - name: Run Syft SBoM scan
         uses: anchore/sbom-action@v0.17.8


### PR DESCRIPTION
## Summary

- Replaces raw `docker build` / `docker push` CLI steps with `docker/setup-buildx-action` (driver: remote) + `docker/build-push-action`
- BuildKit endpoint: `tcp://buildkitd.arc-runners.svc.cluster.local:1234` — shared cluster service deployed via pgk8s ArgoCD
- Required because `containerMode: kubernetes` (ARC runners, PGM-155) provides no Docker daemon

## Context

Part of PGM-155 — fixing slow GHA self-hosted runner startup. Switching from `containerMode: dind` to `containerMode: kubernetes` eliminates the 15–30s DinD daemon init overhead, but removes the in-pod Docker daemon that `docker build` requires.

BuildKit runs as a shared Deployment in `arc-runners`, giving all runner pods a daemonless build backend without per-job daemon startup cost.

## Test plan

- [ ] Merge pgk8s PR for buildkitd deployment first (ArgoCD must sync buildkitd pod before this workflow runs)
- [ ] Trigger workflow on a `*.*.*` tag or via workflow_dispatch
- [ ] Confirm image pushed to `macro.int.pgmac.net:5000/nagios:<tag>`
- [ ] Confirm SBoM scan and Dependency Track upload succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)