### PR TITLE
Migrate Slack notifications to pg-actions reusable workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,8 @@ on:
       - "*.*.*"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   slack-start:
     uses: pgmac-net/pg-actions/.github/workflows/slack-notify-start.yml@main

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,8 +5,14 @@ on:
     tags:
       - "*.*.*"
   workflow_dispatch:
+
 jobs:
+  slack-start:
+    uses: pgmac-net/pg-actions/.github/workflows/slack-notify-start.yml@main
+    secrets: inherit
+
   build-n-push:
+    needs: [slack-start]
     permissions:
       id-token: write
       attestations: write
@@ -71,54 +77,13 @@ jobs:
           bomfilename: "syft-sbom.json"
           autocreate: false
 
-      - name: Exit code failure
-        if: failure()
-        run: |
-          echo "colour=danger" >> $GITHUB_ENV
-          echo "icon=🛑" >> $GITHUB_ENV
-
-      - name: Exit code cancelled
-        if: cancelled()
-        run: |
-          echo "colour=warning" >> $GITHUB_ENV
-          echo "icon=⚠" >> $GITHUB_ENV
-
-      - name: Exit code success
-        if: success()
-        run: |
-          echo "colour=good" >> $GITHUB_ENV
-          echo "icon=✅" >> $GITHUB_ENV
-
-      - name: Send Slack message
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "channel": "builds",
-              "attachments": [
-                {
-                  "mrkdwn_in": ["text", "pretext"],
-                  "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':point_right: Manually triggered') }},
-                  "color": "${{ env.colour || 'grey' }}",
-                  "pretext": "${{ env.icon || '?' }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
-                  "author_name": "${{ github.triggering_actor || github.actor }}",
-                  "title": "${{ github.workflow }}",
-                  "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                  "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':point_right: Manually triggered') }}
-                },
-                {
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  slack-end:
+    if: always()
+    needs: [slack-start, build-n-push]
+    uses: pgmac-net/pg-actions/.github/workflows/slack-notify-end.yml@main
+    with:
+      ts: ${{ needs.slack-start.outputs.ts }}
+      start: ${{ needs.slack-start.outputs.start }}
+      startfmt: ${{ needs.slack-start.outputs.startfmt }}
+      status: ${{ needs.build-n-push.result }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces inline `slackapi/slack-github-action` steps with centralised `pg-actions` reusable workflows
- Restructures single-job workflow into 3-job pattern: `slack-start` → build → `slack-end`
- Removes ~50 lines of duplicated timing, status, and Slack notification logic per repo

## Test plan
- [ ] Verify workflow triggers on next tag push
- [ ] Confirm Slack start notification appears when job begins
- [ ] Confirm Slack end notification updates with correct status and runtime
- [ ] Confirm build steps complete as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)